### PR TITLE
Fixed bug with `sitemap` directive analysis (incorrect diagnostic issue)

### DIFF
--- a/src/Core/Analysis.ts
+++ b/src/Core/Analysis.ts
@@ -69,13 +69,15 @@ export const analyzeRobotsDotTextConfig = function(
 					if (directiveName.toLowerCase() === "user-agent") {
 						userAgentDirectiveFound = true;
 					} else {
-						createDiagnosticIssue(
-							diagnosticList,
-							"No user-agent specified.",
-							token.line.sanitizedRange,
-							DiagnosticSeverity.Error,
-							true
-						);
+						if (directiveName.toLowerCase() !== "sitemap") {
+							createDiagnosticIssue(
+								diagnosticList,
+								"No user-agent specified.",
+								token.line.sanitizedRange,
+								DiagnosticSeverity.Error,
+								true
+							);
+						}
 					}
 				}
 


### PR DESCRIPTION
The `sitemap` directive can be used without a `user-agent` parent directive.