### PR TITLE
Updated tokenization strategy to separate value from inline comment

### DIFF
--- a/src/Core/Format.ts
+++ b/src/Core/Format.ts
@@ -11,7 +11,7 @@ export const formatRobotsDotTextDocument = function(document: TextDocument): Tex
 	const formatTextEditList: TextEdit[] = [];
 
 	for (const token of robotsDotTextTokens) {
-		formatTextEditList.push(TextEdit.replace(token.line.rawRange, token.toString()))
+		formatTextEditList.push(TextEdit.replace(token.line.rawRange, token.toString()));
 	}
 
 	return formatTextEditList;


### PR DESCRIPTION
If the `Crawl-delay` directive has an inline comment and a number value, the syntax analyzer states that the value is not valid even though it is. The reason why this happens is because the comment is accounted for in the directive's value. This behavior happens on the `Sitemap` directive as well.

This pull request solves this issue by separating a directive's value and inline comment.