### PR TITLE
Added `From` HTTP header to the extension's web crawler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@types/glob": "^8.1.0",
 				"@types/mocha": "^10.0.1",
 				"@types/node": "20.2.5",
+				"@types/node-fetch": "^2.6.6",
 				"@types/vscode": "^1.81.0",
 				"@typescript-eslint/eslint-plugin": "^5.59.8",
 				"@typescript-eslint/parser": "^5.59.8",
@@ -300,6 +301,16 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
 			"integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
 			"dev": true
+		},
+		"node_modules/@types/node-fetch": {
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
+			"integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"form-data": "^4.0.0"
+			}
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.0",
@@ -846,6 +857,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1081,6 +1098,18 @@
 			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -1155,6 +1184,15 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
+		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
 		"node_modules/diff": {
 			"version": "5.0.0",
@@ -1596,6 +1634,20 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
+		},
+		"node_modules/form-data": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"dev": true,
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/formdata-polyfill": {
 			"version": "4.0.10",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
 		"@types/glob": "^8.1.0",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "20.2.5",
+		"@types/node-fetch": "^2.6.6",
 		"@types/vscode": "^1.81.0",
 		"@typescript-eslint/eslint-plugin": "^5.59.8",
 		"@typescript-eslint/parser": "^5.59.8",

--- a/src/Commands/CommandHandler.ts
+++ b/src/Commands/CommandHandler.ts
@@ -3,7 +3,7 @@
  *  @author          Darian Benam <darian@darianbenam.com>
  */
 
-import { getBotUserAgent, validateHttpUrl } from "../Networking/Http";
+import { getCrawlerHttpHeaders, validateHttpUrl } from "../Networking/Http";
 import fetch, { Response } from "node-fetch";
 import { ExtensionContext, Range, TextDocument, TextEditor, TextEditorEdit, window } from "vscode";
 
@@ -29,7 +29,7 @@ export const importRobotsDotTextFileFromWeb = async function(context: ExtensionC
 		const response: Response = await fetch(robotsDotTextLocation, {
 			headers: {
 				"Accept": "text/plain",
-				"User-Agent": getBotUserAgent(context)
+				...getCrawlerHttpHeaders(context)
 			}
 		});
 

--- a/src/Networking/Http.ts
+++ b/src/Networking/Http.ts
@@ -5,8 +5,16 @@
 
 import { ExtensionContext, version } from "vscode";
 
-export const getBotUserAgent = function(context: ExtensionContext): string {
-	return `Mozilla/5.0 (compatible; Visual Studio Code/${version}; Robots.txt Support for Visual Studio Code/${context.extension.packageJSON.version}; +https://github.com/BeardedFish/vscode-robots-dot-txt-support)`;
+export type RobotsDotTextCrawlerHttpHeaders = {
+	"User-Agent": string,
+	"From": string
+};
+
+export const getCrawlerHttpHeaders = function(context: ExtensionContext): RobotsDotTextCrawlerHttpHeaders {
+	return {
+		"User-Agent": `Mozilla/5.0 (compatible; Visual Studio Code/${version}; Robots.txt Support for Visual Studio Code/${context.extension.packageJSON.version}; +https://github.com/BeardedFish/vscode-robots-dot-txt-support)`,
+		"From": "darian@darianbenam.com"
+	};
 }
 
 export const validateHttpUrl = function(value: string): string | null {


### PR DESCRIPTION
According to [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/):

> The `From` request header contains an Internet email address for a human user who controls the requesting user agent.
>
> If you are running a robotic user agent (e.g. a crawler), the `From` header must be sent, so you can be contacted if problems occur on servers, such as if the robot is sending excessive, unwanted, or invalid requests.

Since the `Import Robots.txt File From Web` command sends a crawl request to retrieve the `robots.txt` contents of a website, it is a good idea to add this HTTP header to the request.

MDN Web Docs Article: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/From